### PR TITLE
hpp-tutorial-1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
                 ros-core
                 turtlesim
                 pkgs.python3Packages.example-robot-data # for availability in AMENT_PREFIX_PATH
+                pkgs.python3Packages.hpp-tutorial # for availability in AMENT_PREFIX_PATH
               ];
             };
         };


### PR DESCRIPTION
In this PR we fix the usage of the hpp-tutorial-1.
We need https://github.com/Gepetto/nix/pull/14 to be merged before this PR.

There is still an issue upon running the hpp-tutorial-1:
```
$ hpp-tutorial-1
Could not load spline-gradient-based.so
# Solution path.
path = list ()
path.append ((-3.2000000000000001776,-4,1,0,0.2000000000000000111,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,1,0,0,0,0,0,0,0,))
<very verbose numerical result from HPP>
```
The `Could not load spline-gradient-based.so` maybe be an issue but I am sure where to look here. And HPP seems happy with it...