### PR TITLE
ros-{humble,jazzy}-linear-feedback-controller: 1.0.2 -> 2.0.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -230,8 +230,6 @@
         "src-example-parallel-robots": "src-example-parallel-robots",
         "src-franka-description": "src-franka-description",
         "src-gepetto-viewer": "src-gepetto-viewer",
-        "src-linear-feedback-controller": "src-linear-feedback-controller",
-        "src-linear-feedback-controller-jazzy": "src-linear-feedback-controller-jazzy",
         "src-toolbox-parallel-robots": "src-toolbox-parallel-robots",
         "treefmt-nix": "treefmt-nix"
       }
@@ -314,39 +312,6 @@
         "owner": "Gepetto",
         "ref": "devel",
         "repo": "gepetto-viewer",
-        "type": "github"
-      }
-    },
-    "src-linear-feedback-controller": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1744374949,
-        "narHash": "sha256-xlMLxL5CPKifbDGDUa46bLHlnVneVWuAMZBkeKQqBsU=",
-        "owner": "loco-3d",
-        "repo": "linear-feedback-controller",
-        "rev": "ae453a3308abd32bc627bffe95cca5458c4f767b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "loco-3d",
-        "repo": "linear-feedback-controller",
-        "type": "github"
-      }
-    },
-    "src-linear-feedback-controller-jazzy": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1743498558,
-        "narHash": "sha256-Wvk/QZUFJXsdifvnu4zb1YHplTx5hl96t8fnOMfTZ4M=",
-        "owner": "loco-3d",
-        "repo": "linear-feedback-controller",
-        "rev": "8c7760e79883e345342a2445daf54076084a5bb6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "loco-3d",
-        "ref": "jazzy",
-        "repo": "linear-feedback-controller",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -71,14 +71,6 @@
       url = "github:Gepetto/gepetto-viewer/devel";
       flake = false;
     };
-    src-linear-feedback-controller = {
-      url = "github:loco-3d/linear-feedback-controller";
-      flake = false;
-    };
-    src-linear-feedback-controller-jazzy = {
-      url = "github:loco-3d/linear-feedback-controller/jazzy";
-      flake = false;
-    };
     src-toolbox-parallel-robots = {
       url = "github:gepetto/toolbox-parallel-robots";
       flake = false;
@@ -159,7 +151,6 @@
                 inherit (inputs)
                   # keep-sorted start
                   src-agimus-msgs
-                  src-linear-feedback-controller
                   # keep-sorted end
                   ;
                 franka-description = humble-prev.franka-description.overrideAttrs {
@@ -179,7 +170,6 @@
                 inherit (inputs)
                   # keep-sorted start
                   src-agimus-msgs
-                  src-linear-feedback-controller-jazzy
                   # keep-sorted end
                   ;
               }

--- a/humble-pkgs/linear-feedback-controller.nix
+++ b/humble-pkgs/linear-feedback-controller.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
 
-  src-linear-feedback-controller,
+  fetchFromGitHub,
 
   # nativeBuildInputs
   cmake,
@@ -25,11 +25,16 @@
   realtime-tools,
   rclcpp-lifecycle,
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "linear-feedback-controller";
-  version = "1.0.2";
+  version = "2.0.0";
 
-  src = src-linear-feedback-controller;
+  src = fetchFromGitHub {
+    owner = "loco-3d";
+    repo = "linear-feedback-controller";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WB0QXTY74jqeYIt+lv5Y9slMw6lx8FfHO26aGpoX7T0=";
+  };
 
   nativeBuildInputs = [
     cmake
@@ -76,4 +81,4 @@ stdenv.mkDerivation {
     maintainers = [ lib.maintainers.nim65s ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/jazzy-pkgs/linear-feedback-controller.nix
+++ b/jazzy-pkgs/linear-feedback-controller.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
 
-  src-linear-feedback-controller-jazzy,
+  fetchFromGitHub,
 
   # nativeBuildInputs
   cmake,
@@ -25,11 +25,16 @@
   realtime-tools,
   rclcpp-lifecycle,
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "linear-feedback-controller";
-  version = "1.0.2";
+  version = "2.0.0";
 
-  src = src-linear-feedback-controller-jazzy;
+  src = fetchFromGitHub {
+    owner = "loco-3d";
+    repo = "linear-feedback-controller";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WB0QXTY74jqeYIt+lv5Y9slMw6lx8FfHO26aGpoX7T0=";
+  };
 
   nativeBuildInputs = [
     cmake
@@ -79,4 +84,4 @@ stdenv.mkDerivation {
     maintainers = [ lib.maintainers.nim65s ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
to fix update-flake-lock action in https://github.com/Gepetto/nix/actions/runs/14554602630/job/40829866291:
```
        … while updating the lock file of flake 'git+file:///home/runner/work/nix/nix?ref=refs/heads/main&rev=897c9069baf4ffe083c9a253298b65a6d2a95ad2&shallow=1'

       … while updating the flake input 'src-linear-feedback-controller-jazzy'

       … while fetching the input 'github:loco-3d/linear-feedback-controller/jazzy'

       error: unable to download 'https://api.github.com/repos/loco-3d/linear-feedback-controller/commits/jazzy': HTTP error 422

       response body:

       {
         "message": "No commit found for SHA: jazzy",
         "documentation_url": "https://docs.github.com/rest/commits/commits#get-a-commit",
         "status": "422"
       }