### PR TITLE
Use buildRosPackage for all ros packages.

### DIFF
--- a/humble-pkgs/agimus-controller-ros.nix
+++ b/humble-pkgs/agimus-controller-ros.nix
@@ -1,6 +1,7 @@
 {
   lib,
   python3Packages,
+  buildRosPackage,
 
   src-agimus-controller,
 
@@ -23,17 +24,13 @@
   geometry-msgs,
   builtin-interfaces,
 }:
-python3Packages.buildPythonPackage {
+buildRosPackage {
   pname = "agimus-controller-ros";
   version = "0-unstable-2025-04-23";
 
   src = src-agimus-controller;
   sourceRoot = "source/agimus_controller_ros";
-
-  dontUseCmakeConfigure = true;
-  dontUseCmakeBuild = true;
-  dontUseCmakeCheck = true;
-  dontUseCmakeInstall = true;
+  buildType = "ament_python";
 
   nativeBuildInputs = [
     fmt

--- a/humble-pkgs/agimus-msgs.nix
+++ b/humble-pkgs/agimus-msgs.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  buildRosPackage,
 
   src-agimus-msgs,
 
@@ -18,7 +18,7 @@
   sensor-msgs,
   std-msgs,
 }:
-stdenv.mkDerivation {
+buildRosPackage {
   pname = "agimus-msgs";
   version = "0.0.2";
 

--- a/humble-pkgs/linear-feedback-controller-msgs.nix
+++ b/humble-pkgs/linear-feedback-controller-msgs.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  buildRosPackage,
 
   fetchFromGitHub,
 
@@ -22,14 +22,17 @@
   sensor-msgs,
   tf2-eigen,
 }:
-stdenv.mkDerivation (finalAttrs: {
-  pname = "linear-feedback-controller-msgs";
+let
   version = "1.0.0";
+in
+buildRosPackage {
+  pname = "linear-feedback-controller-msgs";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "loco-3d";
     repo = "linear-feedback-controller-msgs";
-    tag = "v${finalAttrs.version}";
+    tag = "v${version}";
     hash = "sha256-iolp/25VccP7knwRUOj4eQ5kGlcvWEiCfTYHkx/AUrA=";
   };
 
@@ -62,4 +65,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.nim65s ];
     platforms = lib.platforms.linux;
   };
-})
+}

--- a/humble-pkgs/linear-feedback-controller.nix
+++ b/humble-pkgs/linear-feedback-controller.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  buildRosPackage,
 
   fetchFromGitHub,
 
@@ -28,14 +28,17 @@
   # checkInputs
   gtest,
 }:
-stdenv.mkDerivation (finalAttrs: {
-  pname = "linear-feedback-controller";
+let
   version = "2.0.0";
+in
+buildRosPackage {
+  pname = "linear-feedback-controller";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "loco-3d";
     repo = "linear-feedback-controller";
-    tag = "v${finalAttrs.version}";
+    tag = "v${version}";
     hash = "sha256-WB0QXTY74jqeYIt+lv5Y9slMw6lx8FfHO26aGpoX7T0=";
   };
 
@@ -88,4 +91,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.nim65s ];
     platforms = lib.platforms.linux;
   };
-})
+}

--- a/jazzy-pkgs/agimus-controller-ros.nix
+++ b/jazzy-pkgs/agimus-controller-ros.nix
@@ -1,6 +1,7 @@
 {
   lib,
   python3Packages,
+  buildRosPackage,
 
   src-agimus-controller,
 
@@ -23,17 +24,13 @@
   geometry-msgs,
   builtin-interfaces,
 }:
-python3Packages.buildPythonPackage {
+buildRosPackage {
   pname = "agimus-controller-ros";
   version = "0-unstable-2025-04-23";
 
   src = src-agimus-controller;
   sourceRoot = "source/agimus_controller_ros";
-
-  dontUseCmakeConfigure = true;
-  dontUseCmakeBuild = true;
-  dontUseCmakeCheck = true;
-  dontUseCmakeInstall = true;
+  buildType = "ament_python";
 
   nativeBuildInputs = [
     fmt

--- a/jazzy-pkgs/agimus-msgs.nix
+++ b/jazzy-pkgs/agimus-msgs.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  buildRosPackage,
 
   src-agimus-msgs,
 
@@ -18,7 +18,7 @@
   sensor-msgs,
   std-msgs,
 }:
-stdenv.mkDerivation {
+buildRosPackage {
   pname = "agimus-msgs";
   version = "0.0.2";
 

--- a/jazzy-pkgs/linear-feedback-controller-msgs.nix
+++ b/jazzy-pkgs/linear-feedback-controller-msgs.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  buildRosPackage,
 
   fetchFromGitHub,
 
@@ -22,14 +22,17 @@
   sensor-msgs,
   tf2-eigen,
 }:
-stdenv.mkDerivation (finalAttrs: {
-  pname = "linear-feedback-controller-msgs";
+let
   version = "1.0.0";
+in
+buildRosPackage {
+  pname = "linear-feedback-controller-msgs";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "loco-3d";
     repo = "linear-feedback-controller-msgs";
-    tag = "v${finalAttrs.version}";
+    tag = "v${version}";
     hash = "sha256-iolp/25VccP7knwRUOj4eQ5kGlcvWEiCfTYHkx/AUrA=";
   };
 
@@ -62,4 +65,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.nim65s ];
     platforms = lib.platforms.linux;
   };
-})
+}

--- a/jazzy-pkgs/linear-feedback-controller.nix
+++ b/jazzy-pkgs/linear-feedback-controller.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  buildRosPackage,
 
   fetchFromGitHub,
 
@@ -28,14 +28,17 @@
   # checkInputs
   gtest,
 }:
-stdenv.mkDerivation (finalAttrs: {
-  pname = "linear-feedback-controller";
+let
   version = "2.0.0";
+in
+buildRosPackage {
+  pname = "linear-feedback-controller";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "loco-3d";
     repo = "linear-feedback-controller";
-    tag = "v${finalAttrs.version}";
+    tag = "v${version}";
     hash = "sha256-WB0QXTY74jqeYIt+lv5Y9slMw6lx8FfHO26aGpoX7T0=";
   };
 
@@ -91,4 +94,4 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.nim65s ];
     platforms = lib.platforms.linux;
   };
-})
+}


### PR DESCRIPTION
This is a minor bug fix that makes the ROS packages built by this overlay compatible with the ROS2 tools like `ros2 run` or `ros2 launch`.

One would prefer to build the ROS packages using the `ros-nix-overlay` distros call: `buildRosPackage`.

For example for python package it installs the binaries in the lib folder as ROS expect and not in the default Python layout which means the bin folder on linux. So calling the `python3Packages.buildPythonPackages`  on a ROS2 Python package would not allow the `ros2 run` executable to find the executable as it would look for them in `lib/<package_name>` instead of `bin`.
I also handles the propagation of the call to CMake. It disables it in case the package is a Python one.