### PR TITLE
template: fail-fast even on single job

### DIFF
--- a/templates/default/.github/workflows/nix.yml
+++ b/templates/default/.github/workflows/nix.yml
@@ -14,6 +14,7 @@ jobs:
   nix:
     runs-on: "${{ matrix.os }}-latest"
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu]
     steps:


### PR DESCRIPTION
for extends & (later) macos